### PR TITLE
FIX: allow for output token to stay in contract on interim route

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,13 @@
 name: test
 
-on: workflow_dispatch
+on: pull_request
 
 env:
   FOUNDRY_PROFILE: ci
 
 jobs:
   check:
-    strategy:
-      fail-fast: true
-
-    name: Foundry project
+    name: Minima
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -22,7 +19,7 @@ jobs:
         with:
           version: nightly
 
-      - name: Sets up rep
+      - name: Sets up repo
         run: |
           sh ./shell/init.sh
         id: prepare

--- a/src/MinimaRouterV1.sol
+++ b/src/MinimaRouterV1.sol
@@ -408,8 +408,6 @@ contract MinimaRouterV1 is IMinimaRouterV1, Ownable {
             details.path[details.path.length - 1].length - 1
         ];
 
-        bool[] memory completedPaths = new bool[](details.path.length);
-
         for (uint256 i = 0; i < details.path.length; i++) {
             require(
                 details.pairs[i].length > 0,
@@ -455,8 +453,14 @@ contract MinimaRouterV1 is IMinimaRouterV1, Ownable {
 
                 for (uint256 k = 0; k < transferAmounts.length; k++) {
                     uint8 toIdx = details.divisors[i][k].toIdx;
+
+                    // Allow output token to stay in this contract, it will be transfered out following the complete path execution
+                    if (toIdx == 0 && details.divisors[i][k].token == output) {
+                        continue;
+                    }
+
                     require(
-                        completedPaths[toIdx] == false && toIdx != i,
+                        toIdx > i,
                         "MinimaRouterV1: Can not transfer to completed path!"
                     );
 
@@ -471,7 +475,6 @@ contract MinimaRouterV1 is IMinimaRouterV1, Ownable {
                     }
                 }
             }
-            completedPaths[i] = true;
         }
 
         uint256 tradeOutput = SafeMath.sub(


### PR DESCRIPTION
Issue raised during second review:

```
We noticed that with the new changes, if a path creates the output token but is not the final path, it is forced to send the output token to another pair rather than keep it in the contract.
We see that L451 allows the contract to keep the output token if its the final path in deailts.path[], but it seems that this exception should be extended to all paths that create the output token.
```

This fixes the raised issue by allowing the `toIdx` to be 0 if and only if the divisor token is the output token.