### PR TITLE
Update Comments to Make Initial Owner Conditions More Apparent

### DIFF
--- a/src/MinimaRouterV1.sol
+++ b/src/MinimaRouterV1.sol
@@ -96,24 +96,24 @@ contract MinimaRouterV1 is IMinimaRouterV1, Ownable {
     }
 
     /**
-		admin should be a multisig wallet
+		Initial owner should be a multisig wallet
 	 */
-    constructor(address admin, address[] memory initialSigners)
+    constructor(address owner, address[] memory initialSigners)
         public
         Ownable()
     {
         require(
-            admin != address(0),
+            owner != address(0),
             "MinimaRouterV1: Admin can not be 0 address!"
         );
         require(
-            isContract(admin),
+            isContract(owner),
             "MinimaRouterV1: Minima must be deployed from contract!"
         );
-        transferOwnership(admin);
+        transferOwnership(owner);
 
         // Make the null tenant the admin wallet, with default fee numerator of 0
-        partnerAdmin[0] = admin;
+        partnerAdmin[0] = owner;
 
         // Add the initial signers
         for (uint8 i = 0; i < initialSigners.length; i++) {


### PR DESCRIPTION
Updates the comment above the constructor to communicate that simply the _initial_ owner should be a smart contract.  

We want to be able to add non-smart contract admins for ease of signing quotes offchain.